### PR TITLE
Fix benchmark tests when running with minified library code

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -1709,18 +1709,18 @@
                 tdSource = getSource(teardown);
 
             _.assign(templateData, {
-              'setup': (suSource == '' || suSource == '// No operation performed.') ? 'deferred.suResolve();' : getSource(setup),
+              'setup': (suSource == '' || suSource == '// No operation performed.') ? interpolate('d#.suResolve();') : getSource(setup),
               'fn': getSource(fn),
               'fnArg': fnArg,
-              'teardown': (tdSource == '' || tdSource == '// No operation performed.') ? 'deferred.tdResolve();' : getSource(teardown)
+              'teardown': (tdSource == '' || tdSource == '// No operation performed.') ? interpolate('d#.tdResolve();') : getSource(teardown)
             });
           }
           else {
             _.assign(templateData, {
-              'setup': suArg ? interpolate('m#.setup(' + suArg + ');') : 'deferred.suResolve();',
+              'setup': suArg ? interpolate('m#.setup(' + suArg + ');') : interpolate('d#.suResolve();'),
               'fn': interpolate('m#.fn(' + fnArg + ');'),
               'fnArg': fnArg,
-              'teardown': tdArg ? interpolate('m#.teardown(' + tdArg + ');') : 'deferred.tdResolve();'
+              'teardown': tdArg ? interpolate('m#.teardown(' + tdArg + ');') : interpolate('d#.tdResolve();')
             });
           }
         }


### PR DESCRIPTION
This fixes an issue I found when using benchmark and my library was minified. I don't really understand all of the implications, but what seems to have happened is that the line "deferred.suResolve()" errors as "deferred" was undefined in minified.

By inspection, I noted that similar code was using the "interpolate" function and replaced "#d" with the name of the deferred variable.